### PR TITLE
Limit python-telegram-bot to version <20 and create DB in local path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "requests>=2.26.0",
-        "python-telegram-bot>=13.15",
+        "python-telegram-bot>=13.15,<20.0.0",
         "beautifulsoup4>=4.11.1",
         "tinydb>=4.7.0",
         "lxml>=4.9.1"

--- a/yoku/database.py
+++ b/yoku/database.py
@@ -6,7 +6,7 @@ from yoku.consts import KEY_ITEM_ID, KEY_CHAT_ID
 from yoku.scrape import search
 from yoku.botutils import notify
 
-DB_PATH = Path.cwd(__file__) / "db.json"
+DB_PATH = Path.cwd() / "db.json"
 
 TABLE_QUERIES = "queries"
 KEY_QUERY = "query"

--- a/yoku/database.py
+++ b/yoku/database.py
@@ -6,7 +6,7 @@ from yoku.consts import KEY_ITEM_ID, KEY_CHAT_ID
 from yoku.scrape import search
 from yoku.botutils import notify
 
-DB_PATH = Path(__file__).resolve().parent / "db.json"
+DB_PATH = Path.cwd(__file__) / "db.json"
 
 TABLE_QUERIES = "queries"
 KEY_QUERY = "query"


### PR DESCRIPTION
Thank you for creating this great library!

I had two issues when deploying it with pip. Version 20.0 of python-telegram-bot has changed interfaces significantly so I limited the version in setup.py.

I also made a small tweak to create the DB in the local path instead of the yoku folder under dist-packages to make sure no particular privileges are required.